### PR TITLE
Reformat extension list as 3xN table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [GitHub Awesome Autocomplete](#github-awesome-autocomplete)
 - [Octotree](#octotree)
 - [ZenHub](#zenhub)
-- [github.expandinizr](#github.expandinizr)
+- [github.expandinizr](#githubexpandinizr)
 - [News Feed for GitHub](#news-feed-for-github)
 - [Isometric Contributions](#isometric-contributions)
 - [Gitter Helper](#gitter-helper)
@@ -41,293 +41,329 @@
 - [GitHub Grouped News](#github-grouped-news)
 
 
-## [Notifier for GitHub](https://github.com/sindresorhus/notifier-for-github)
-<a href="https://chrome.google.com/webstore/detail/notifier-for-github/lmjdlojahmbbcodnpecnjnmlddbkjhnn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/notifier-for-github/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/github-notifier/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-<a href="https://github.com/sindresorhus/notifier-for-github-safari/releases"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
-
-Displays your GitHub notifications unread count. Supports GitHub Enterprise and an option to only show unread count for issues you're participating in. You can click the icon to quickly see your unread notifications.
-
-![List prompt](https://dl.dropboxusercontent.com/s/c7egcrhq1wvff5r/github-notifier.jpg)
-
-
-## [Tab Size on GitHub](https://github.com/sindresorhus/tab-size-on-github)
-<a href="https://chrome.google.com/webstore/detail/tab-size-on-github/ofjbgncegkdemndciafljngjbdpfmbkn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/github-tab-size/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Make tab indented code more readable by forcing the tab size to 4 instead of 8.
-
-![List prompt](https://dl.dropboxusercontent.com/s/srd0ik8tbpjzi0v/github-tab-size.jpg)
-
-
-## [Hide files on GitHub](https://github.com/sindresorhus/hide-files-on-github)
-<a href="https://chrome.google.com/webstore/detail/hide-files-on-github/lpnakhpaodhdkleejaehlapdhbgjbddp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/github-hide-files/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Hide dotfiles from the GitHub file browser.
-
-![List prompt](https://dl.dropboxusercontent.com/s/80jpb795dckfel7/github-hide-files.jpg)
-
-
-## [OctoLinker](https://github.com/OctoLinker/browser-extension)
-<a href="https://chrome.google.com/webstore/detail/octolinker/jlmafbaeoofdegohdhinkhilhclaklkp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/octolinker/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/octolinker/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Octo-Linker is a Browser Extension which links NPM, bower, Composer & Duo dependencies to their GitHub repository page. It also solve require() statments in a .js, .jsx, .coffee or .md file.
-
-![List prompt](https://dl.dropboxusercontent.com/s/wl0s1rishc4e8lu/github-linker.jpg)
-
-
-## [GitHub Highlight Selected](https://github.com/Nuclides/github-highlight-selected)
-<a href="https://chrome.google.com/webstore/detail/github-highlight-selected/lhiklbgjcblimmjjflobpncgihagcmbj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://github.com/Nuclides/github-highlight-selected/blob/master/README.md"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
-
-Highlight selected word in GitHub source view like Sublime Text.
-
-![List prompt](https://dl.dropboxusercontent.com/s/2un7ezpdipunn70/github-highlight-selected.jpg)
-
-
-## [GitHub Awesome Autocomplete](https://github.com/algolia/github-awesome-autocomplete)
-<a href="https://chrome.google.com/webstore/detail/github-awesome-autocomple/djkfdjpoelphhdclfjhnffmnlnoknfnd"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/github-awesome-autocomplete/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-Simple and discreet extension that enhances GitHub's search, letting you search for repositories and people faster than ever.
-
-![List prompt](https://dl.dropboxusercontent.com/s/zg3cblx3q8fhbkl/github-awesome-autocomplete.jpg)
-
-
-## [Octotree](https://github.com/buunguyen/octotree)
-<a href="https://chrome.google.com/webstore/detail/octotree/bkhaagjahfmjljalopjnoealnfndnagc"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/octotree/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-<a href="https://github.com/buunguyen/octotree/#install-on-safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/octotree/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Useful for developers who frequently read source in GitHub and do not want to download or checkout too many repositories.
-
-![List prompt](https://dl.dropboxusercontent.com/s/87zbki7vvkucphr/octotree.jpg)
-
-
-## ZenHub
-<a href="https://chrome.google.com/webstore/detail/zenhub-for-github/ogcgkffhplmphkaahpmffcafajaocjbd"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://www.zenhub.com/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-ZenHub is the first and only project management suite that works natively within GitHub; enhancing your workflow with features built specifically for startups, fast-moving engineering teams, and the open-source community. The product is a browser extension that injects advanced functionality including real-time drag-and-drop Issue Task Boards, peer feedback via a +1 button, and support for uploading any file type directly into the GitHub interface. ZenHub makes it easy to centralize all processes into GitHub, keeping your team lean and agile.
-
-![List prompt](https://dl.dropboxusercontent.com/s/yosmyg8zsl5tyc5/zenhub.jpg)
-
-
-## [github.expandinizr](https://github.com/thecodejunkie/github.expandinizr)
-<a href="https://chrome.google.com/webstore/detail/githubexpandinizr/cbehdjjcilgnejbpnjhobkiiggkedfib"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Add breakpoints at 1400px, 1600px and 1800px for full GitHub experience on large screens. Also removes the truncating of file and directory names in the repository browser.
-
-![List prompt](https://dl.dropboxusercontent.com/s/7e9g9g0l445j90m/github-expandinizr.jpg)
-
-## [News Feed for GitHub](https://github.com/julmot/news-feed-for-github)
-<a href="https://chrome.google.com/webstore/detail/news-feed-for-github/gbpajmknkcgjeinfbmfeiafhogbhgkjh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/news-feed-for-github/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-A Chrome and Firefox extension that shows notifications when something happens in your GitHub news feed.
-
-![News Feed for GitHub](https://raw.githubusercontent.com/julmot/news-feed-for-github/master/screenshots/chrome.png)
-
-## [Isometric Contributions](https://github.com/jasonlong/isometric-contributions)
-<a href="https://chrome.google.com/webstore/detail/isometric-contributions/mjoedlfflcchnleknnceiplgaeoegien"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://github.com/jasonlong/isometric-contributions#safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
-
-Allows you to toggle between the normal GitHub contribution chart and an isometric pixel art version.
-
-![List prompt](https://dl.dropboxusercontent.com/s/kc1qxqitixx0hfp/isometric-contributions.jpg)
-
-
-## [Gitter Helper](https://github.com/svincent/gitter-chrome)
-<a href="https://chrome.google.com/webstore/detail/gitter-helper-for-github/apahfabdianobklhejoojcpmoegaolpi"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Makes it easy to see if a GitHub project has a [Gitter](https://gitter.im) room.
-
-![List prompt](https://lh3.googleusercontent.com/sRRg2KsBhOnu3RFfLZYDWFEn52hngmM9ygdc-gBvjmY4l8a4moFjgXJTVUVNNj-oIUCplfVwHgQ=s1280-h800-e365-rw)
-
-
-## [Octo Mate](https://github.com/camsong/chrome-github-mate)
-<a href="https://chrome.google.com/webstore/detail/octo-mate/baggcehellihkglakjnmnhpnjmkbmpkf?utm_source=chrome-ntp-icon"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Adds various useful features to GitHub:
-
-1. Download any file by clicking the file icon.
-2. Show tooltip of your unread notifications.
-3. Show Repo size.
-4. Show 'GH Page' link button if it has GitHub Pages.
-5. Tab size customising between 2/4/8 whitespace.
-
-![Download file](https://lh3.googleusercontent.com/kTEhmep4hM1Mknr1ILHgFVIzS8a-WszsdKjV0qH8Qjp7M-rbYA-yNR-WA6voWY7gtG9DIBn7Uw=s640-h400-e365-rw)
-
-
-## [Pages2Repo](https://github.com/Frozenfire92/Pages2Repo)
-<a href="https://chrome.google.com/webstore/detail/pages2repo/afnogakjnebbgcbjkgmhaccljfejeflh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Makes it easy to access repository info from a GitHub pages website.
-
-![List prompt](https://cloud.githubusercontent.com/assets/1393946/11908410/4027dc66-a5dc-11e5-9bce-b028aa884c9a.png)
-
-
-## [Lovely forks](https://github.com/musically-ut/lovely-forks)
-<a href="https://chrome.google.com/webstore/detail/lovely-forks/ialbpcipalajnakfondkflpkagbkdoib"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/lovely-forks/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-See forks with the most stars under the names of repositories.
-
-![Slate fork](https://musicallyut.in/docs/lovely-forks/slate-fork-80.png)
-
-
-## [GitHub Pr Filter](https://github.com/danielhusar/github-pr-filter)
-<a href="https://chrome.google.com/webstore/detail/github-pr-filter/fjmalelcdgindphooaabcgmmnmoclpee"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Add ability to filter files in pull requests.
-
-![GitHub Pr Filter](https://raw.githubusercontent.com/danielhusar/github-pr-filter/master/demo.png)
-
-
-## [GitHub AST Viewer](https://github.com/lukehorvat/github-ast-viewer)
-<a href="https://chrome.google.com/webstore/detail/github-ast-viewer/kgncjlmmhhmhbiiacajdmpnhplahelkh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-View the abstract syntax tree (AST) of code on GitHub.
-
-![GitHub AST Viewer](http://i.imgur.com/jumGRMd.gif)
-
-
-## [GitHub Hovercard](https://github.com/Justineo/github-hovercard)
-<a href="https://chrome.google.com/webstore/detail/github-hovercard/mmoahbbnojgkclgceahhakhnccimnplk"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.mozilla.org/en-US/firefox/addon/github-hovercard/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/github-hovercard/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Neat user/repo/issue hovercard for GitHub.
-
-![GitHub Hovercard](https://github.com/Justineo/github-hovercard/blob/gh-pages/screenshots/2.png)
-
-
-## [GitHub Markdown Outline Extension](https://github.com/dbkaplun/github-markdown-outline-extension)
-<a href="https://chrome.google.com/webstore/detail/github-markdown-outline-e/gccinjjdbfdkkkebfbeipopijjfohfgj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Displays a clickable outline of all topic headers for markdown documents on GitHub
-
-![GitHub Markdown Outline Extension](https://raw.githubusercontent.com/dbkaplun/github-markdown-outline-extension/master/screenshot.png)
-
-## [GitHub Categoric](https://github.com/ozlerhakan/categoric)
-<a href="https://chrome.google.com/webstore/detail/github-categoric/gbfpmfhnfmobaichcfnhdobencecomhg"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Categorize your mixed GitHub notifications
-
-![GitHub Categoric](https://dl.dropboxusercontent.com/u/15056258/screeen.png)
-
-
-## [OctoPreview](https://github.com/DrewML/octo-preview)
-<a href="https://chrome.google.com/webstore/detail/octo-preview/elomekmlfonmdhmpmdfldcjgdoacjcba"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Displays live previews of Markdown comments while you type. Works with Issues + Pull Requests.
-
-![GitHub OctoPreview Extension](https://raw.githubusercontent.com/DrewML/octo-preview/master/example.gif)
-
-
-## [Refined GitHub](https://github.com/sindresorhus/refined-github)
-<a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://github.com/fantattitude/refined-github-safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
-
-Extension that simplifies the GitHub interface and adds useful features.
-
-![Refined GitHub](https://raw.githubusercontent.com/sindresorhus/refined-github/master/screenshot-dashboard.png)
-
-
-## [Show All GitHub Issues](https://github.com/sindresorhus/show-all-github-issues)
-<a href="https://chrome.google.com/webstore/detail/show-all-github-issues/ahkcgmpcfiijldaijfjekdffckpidieb"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://addons.opera.com/en/extensions/details/github-issues-all/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
-
-Show both Issues and Pull Requests in the Issues tab by default. As it previously did.
-
-![Show All GitHub Issues](https://raw.githubusercontent.com/sindresorhus/show-all-github-issues/master/screenshot.png)
-
-
-## [Contributors on GitHub](https://github.com/hzoo/contributors-on-github)
-<a href="https://chrome.google.com/webstore/detail/contributors-on-github/cjbacdldhllelehomkmlniifaojgaeph"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Show the # of PRs and other contributors stats in the Issues/PRs tab. Can be helpful for maintainers that want to know if it's a contributor's first PR.
-
-![Contributors on GitHub](https://github.com/hzoo/contributors-on-github/blob/master/firstpr.gif)
-
-
-## [GifHub](https://github.com/DrewML/GifHub)
-<a href="https://chrome.google.com/webstore/detail/gifhub/lponagpckglibniamicamklhfkoebpeb/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-A Chrome extension that adds a button on GitHub comment toolbars, allowing you to search for (and include) GIFs in comments.
-
-![GifHub](https://cloud.githubusercontent.com/assets/1393946/13860430/911b4ce6-ec88-11e5-9952-11f19baa0190.gif)
-
-## [GitHub Omnibar](https://github.com/jcouyang/gh-omnibar)
-<a href="https://chrome.google.com/webstore/detail/github-omnibar/njccjmmakcbdpnlbodllfgiloenfpocb"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="https://github.com/jcouyang/gh-omnibar#firefox"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-Omnibar for GitHub just like [bitbucket's](https://developer.atlassian.com/blog/2016/02/6-secret-bitbucket-features/?categories=git#omnibar)
-
-![](https://cloud.githubusercontent.com/assets/1235045/13912608/00623f8a-ef7a-11e5-92dc-20cd9815007d.png)
-
-
-## [Twitter for GitHub](https://github.com/bevacqua/twitter-for-github)
-<a href="https://chrome.google.com/webstore/detail/twitter-for-github/joalalcafnlmimkfkihjbdgmphgedojc"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Infers or tries to find GitHub users' Twitter handles and present them to you in the GitHub interface.
-
-![](https://cloud.githubusercontent.com/assets/1393946/14272254/9a83b0a2-fb01-11e5-8d04-52687ae367f8.png)
-
-
-## [Where is it?](https://github.com/WhereIsItDev/whereisit)
-<a href="https://chrome.google.com/webstore/detail/where-is-it/cdgnplmebagbialenimejpokfcodlkdm"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Whereisit makes code navigation on GitHub easier. Look up and jump around class/method definitions with a single click.
-
-![](https://cloud.githubusercontent.com/assets/1393946/15090769/d0472958-1433-11e6-8af0-c5294aae94d6.png)
-
-
-## [Review on Github](https://github.com/bastilian/ReviewOnGitHub)
-
-<a href="https://chrome.google.com/webstore/detail/review-on-github/eenlonmglmdookfbknbmcgjkpomndjdp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Review repositories on GitHub like a Pull Request. This extension adds the ability to github.com to make notes in files and add them as a compiled list to an issue.
-
-## [GitHub Extended](https://github.com/onmyway133/github-extended)
-
-<a href="https://chrome.google.com/webstore/detail/github-extended/doidfnmbfadacpcjkekkgofkmnkljnhi/related"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-A Chrome extension to discover more repositories
-
-
-## [npm-hub](https://github.com/zeke/npm-hub)
-<a href="https://chrome.google.com/webstore/detail/npm-hub/kbbbjimdjbjclaebffknlabpogocablj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-<a href="http://crossrider.com/install/36212-npm-hub"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
-
-When viewing a repository on github.com that has a package.json file, this extension will introspect the dependencies in package.json and display links and description for each dependency, just below the repo's README.
-
-<img width="531" src="https://cloud.githubusercontent.com/assets/1393946/15631842/9dfd38f6-257d-11e6-96b8-f7008937e1ad.png">
-
-
-## [PR file filter for Github](https://github.com/siggysamson/pr-file-filter-for-github#pr-file-filter-for-github)
-<a href="https://chrome.google.com/webstore/detail/pr-file-filter-for-github/jahafomboikfnemnncinlmohmbbbnbkn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-This Chrome extension extends the file search of a pull request to allow for actual filtering with globs.
-
-<img src="https://raw.githubusercontent.com/siggysamson/pr-file-filter-for-github/master/assets/demo.gif">
-
-
-## [Github Travis Stat](https://github.com/Yaowenjie/travis-github-chrome-extension)
-<a href="https://chrome.google.com/webstore/detail/github-travis-stat/ekkfhiophiaakmeppcnkblpbbjlnlnmh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-This extension is to display travis-ci status for repos in github. There is a visual chart which shows build status and duration changes for recent 10 times.
-
-<img src='http://yaowenjie.github.io/images/2016/travis0.png'/>
-
-## [GitHub Grouped News](https://github.com/bfred-it/GitHub-Grouped-News)
-<a href="https://chrome.google.com/webstore/detail/github-grouped-news/failppjoidijbialknplliogdmabniaf"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
-
-Group stars, forks, and other events in your dashboard/news feed.
-
-<img src="https://raw.githubusercontent.com/bfred-it/GitHub-Grouped-News/master/screenshot.png">
+<table>
+  <tr>
+    <td>
+      <h2 id="notifier-for-github">
+        <a href="https://chrome.google.com/webstore/detail/notifier-for-github/lmjdlojahmbbcodnpecnjnmlddbkjhnn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/notifier-for-github/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/github-notifier/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/notifier-for-github-safari/releases"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/notifier-for-github">Notifier for GitHub</a>
+      </h2>
+      <p>Displays your GitHub notifications unread count. Supports GitHub Enterprise and an option to only show unread count for issues you're participating in. You can click the icon to quickly see your unread notifications.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/c7egcrhq1wvff5r/github-notifier.jpg">
+    </td>
+    <td>
+      <h2 id="tab-size-on-github">
+        <a href="https://chrome.google.com/webstore/detail/tab-size-on-github/ofjbgncegkdemndciafljngjbdpfmbkn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/github-tab-size/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/tab-size-on-github">Tab Size on GitHub</a>
+      </h2>
+      <p>Make tab indented code more readable by forcing the tab size to 4 instead of 8.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/srd0ik8tbpjzi0v/github-tab-size.jpg">
+    </td>
+    <td>
+      <h2 id="hide-files-on-github">
+        <a href="https://chrome.google.com/webstore/detail/hide-files-on-github/lpnakhpaodhdkleejaehlapdhbgjbddp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/github-hide-files/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/hide-files-on-github">Hide files on GitHub</a>
+      </h2>
+      <p>Hide dotfiles from the GitHub file browser.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/80jpb795dckfel7/github-hide-files.jpg">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="octolinker">
+        <a href="https://chrome.google.com/webstore/detail/octolinker/jlmafbaeoofdegohdhinkhilhclaklkp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/octolinker/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/octolinker/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/OctoLinker/browser-extension">OctoLinker</a>
+      </h2>
+      <p>Octo-Linker is a Browser Extension which links NPM, bower, Composer &amp; Duo dependencies to their GitHub repository page. It also solve require() statments in a .js, .jsx, .coffee or .md file.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/wl0s1rishc4e8lu/github-linker.jpg">
+    </td>
+    <td>
+      <h2 id="github-highlight-selected">
+        <a href="https://chrome.google.com/webstore/detail/github-highlight-selected/lhiklbgjcblimmjjflobpncgihagcmbj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/Nuclides/github-highlight-selected/blob/master/README.md"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
+        <a href="https://github.com/Nuclides/github-highlight-selected">GitHub Highlight Selected</a>
+      </h2>
+      <p>Highlight selected word in GitHub source view like Sublime Text.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/2un7ezpdipunn70/github-highlight-selected.jpg">
+    </td>
+    <td>
+      <h2 id="github-awesome-autocomplete">
+        <a href="https://chrome.google.com/webstore/detail/github-awesome-autocomple/djkfdjpoelphhdclfjhnffmnlnoknfnd"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/github-awesome-autocomplete/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/algolia/github-awesome-autocomplete">GitHub Awesome Autocomplete</a>
+      </h2>
+      <p>Simple and discreet extension that enhances GitHub's search, letting you search for repositories and people faster than ever.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/zg3cblx3q8fhbkl/github-awesome-autocomplete.jpg">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="octotree">
+        <a href="https://chrome.google.com/webstore/detail/octotree/bkhaagjahfmjljalopjnoealnfndnagc"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/octotree/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/buunguyen/octotree/#install-on-safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/octotree/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/buunguyen/octotree">Octotree</a>
+      </h2>
+      <p>Useful for developers who frequently read source in GitHub and do not want to download or checkout too many repositories.</p>
+      <img alt="List prompt" src="https://dl.dropboxusercontent.com/s/87zbki7vvkucphr/octotree.jpg">
+    </td>
+    <td>
+      <h2 id="zenhub">
+        <a href="https://chrome.google.com/webstore/detail/zenhub-for-github/ogcgkffhplmphkaahpmffcafajaocjbd"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://www.zenhub.com/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <span>ZenHub</span>
+      </h2>
+      <p>ZenHub is the first and only project management suite that works natively within GitHub; enhancing your workflow with features built specifically for startups, fast-moving engineering teams, and the open-source community. The product is a browser extension that injects advanced functionality including real-time drag-and-drop Issue Task Boards, peer feedback via a +1 button, and support for uploading any file type directly into the GitHub interface. ZenHub makes it easy to centralize all processes into GitHub, keeping your team lean and agile.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/yosmyg8zsl5tyc5/zenhub.jpg">
+    </td>
+    <td>
+      <h2 id="githubexpandinizr">
+        <a href="https://chrome.google.com/webstore/detail/githubexpandinizr/cbehdjjcilgnejbpnjhobkiiggkedfib"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/thecodejunkie/github.expandinizr">github.expandinizr</a>
+      </h2>
+      <p>Add breakpoints at 1400px, 1600px and 1800px for full GitHub experience on large screens. Also removes the truncating of file and directory names in the repository browser.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/7e9g9g0l445j90m/github-expandinizr.jpg">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="news-feed-for-github">
+        <a href="https://chrome.google.com/webstore/detail/news-feed-for-github/gbpajmknkcgjeinfbmfeiafhogbhgkjh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/news-feed-for-github/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/julmot/news-feed-for-github">News Feed for GitHub</a>
+      </h2>
+      <p>A Chrome and Firefox extension that shows notifications when something happens in your GitHub news feed.</p>
+      <img width="250" alt="News Feed for GitHub" src="https://raw.githubusercontent.com/julmot/news-feed-for-github/master/screenshots/chrome.png">
+    </td>
+    <td>
+      <h2 id="isometric-contributions">
+        <a href="https://chrome.google.com/webstore/detail/isometric-contributions/mjoedlfflcchnleknnceiplgaeoegien"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/jasonlong/isometric-contributions#safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
+        <a href="https://github.com/jasonlong/isometric-contributions">Isometric Contributions</a>
+      </h2>
+      <p>Allows you to toggle between the normal GitHub contribution chart and an isometric pixel art version.</p>
+      <img width="250" alt="List prompt" src="https://dl.dropboxusercontent.com/s/kc1qxqitixx0hfp/isometric-contributions.jpg">
+    </td>
+    <td>
+      <h2 id="gitter-helper">
+        <a href="https://chrome.google.com/webstore/detail/gitter-helper-for-github/apahfabdianobklhejoojcpmoegaolpi"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/svincent/gitter-chrome">Gitter Helper</a>
+      </h2>
+      <p>Makes it easy to see if a GitHub project has a <a href="https://gitter.im">Gitter</a> room.</p>
+      <img width="250" alt="List prompt" src="https://lh3.googleusercontent.com/sRRg2KsBhOnu3RFfLZYDWFEn52hngmM9ygdc-gBvjmY4l8a4moFjgXJTVUVNNj-oIUCplfVwHgQ=s1280-h800-e365-rw">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="octo-mate">
+        <a href="https://chrome.google.com/webstore/detail/octo-mate/baggcehellihkglakjnmnhpnjmkbmpkf?utm_source=chrome-ntp-icon"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/camsong/chrome-github-mate">Octo Mate</a>
+      </h2>
+      <p>Adds various useful features to GitHub:</p>
+      <ol>
+        <li>Download any file by clicking the file icon.</li>
+        <li>Show tooltip of your unread notifications.</li>
+        <li>Show Repo size.</li>
+        <li>Show 'GH Page' link button if it has GitHub Pages.</li>
+        <li>Tab size customising between 2/4/8 whitespace.</li>
+      </ol>
+      <img width="250" alt="Download file" src="https://lh3.googleusercontent.com/kTEhmep4hM1Mknr1ILHgFVIzS8a-WszsdKjV0qH8Qjp7M-rbYA-yNR-WA6voWY7gtG9DIBn7Uw=s640-h400-e365-rw">
+    </td>
+    <td>
+      <h2 id="pages2repo">
+        <a href="https://chrome.google.com/webstore/detail/pages2repo/afnogakjnebbgcbjkgmhaccljfejeflh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/Frozenfire92/Pages2Repo">Pages2Repo</a>
+      </h2>
+      <p>Makes it easy to access repository info from a GitHub pages website.</p>
+      <img width="250" alt="List prompt" src="https://cloud.githubusercontent.com/assets/1393946/11908410/4027dc66-a5dc-11e5-9bce-b028aa884c9a.png">
+    </td>
+    <td>
+      <h2 id="lovely-forks">
+        <a href="https://chrome.google.com/webstore/detail/lovely-forks/ialbpcipalajnakfondkflpkagbkdoib"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/lovely-forks/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/musically-ut/lovely-forks">Lovely forks</a>
+      </h2>
+      <p>See forks with the most stars under the names of repositories.</p>
+      <img alt="Slate fork" src="https://musicallyut.in/docs/lovely-forks/slate-fork-80.png">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="github-pr-filter">
+        <a href="https://chrome.google.com/webstore/detail/github-pr-filter/fjmalelcdgindphooaabcgmmnmoclpee"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/danielhusar/github-pr-filter">GitHub Pr Filter</a>
+      </h2>
+      <p>Add ability to filter files in pull requests.</p>
+      <img alt="GitHub Pr Filter" src="https://raw.githubusercontent.com/danielhusar/github-pr-filter/master/demo.png">
+    </td>
+    <td>
+      <h2 id="github-ast-viewer">
+        <a href="https://chrome.google.com/webstore/detail/github-ast-viewer/kgncjlmmhhmhbiiacajdmpnhplahelkh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/lukehorvat/github-ast-viewer">GitHub AST Viewer</a>
+      </h2>
+      <p>View the abstract syntax tree (AST) of code on GitHub.</p>
+      <img width="250" alt="GitHub AST Viewer" src="http://i.imgur.com/jumGRMd.gif">
+    </td>
+    <td>
+      <h2 id="github-hovercard">
+        <a href="https://chrome.google.com/webstore/detail/github-hovercard/mmoahbbnojgkclgceahhakhnccimnplk"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/github-hovercard/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/github-hovercard/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/Justineo/github-hovercard">GitHub Hovercard</a>
+      </h2>
+      <p>Neat user/repo/issue hovercard for GitHub.</p>
+      <img width="250" alt="GitHub Hovercard" src="https://github.com/Justineo/github-hovercard/blob/gh-pages/screenshots/2.png">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="github-markdown-outline-extension">
+        <a href="https://chrome.google.com/webstore/detail/github-markdown-outline-e/gccinjjdbfdkkkebfbeipopijjfohfgj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/dbkaplun/github-markdown-outline-extension">GitHub Markdown Outline Extension</a>
+      </h2>
+      <p>Displays a clickable outline of all topic headers for markdown documents on GitHub</p>
+      <img width="250" alt="GitHub Markdown Outline Extension" src="https://raw.githubusercontent.com/dbkaplun/github-markdown-outline-extension/master/screenshot.png">
+    </td>
+    <td>
+      <h2 id="github-categoric">
+        <a href="https://chrome.google.com/webstore/detail/github-categoric/gbfpmfhnfmobaichcfnhdobencecomhg"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/ozlerhakan/categoric">GitHub Categoric</a>
+      </h2>
+      <p>Categorize your mixed GitHub notifications</p>
+      <img width="250" alt="GitHub Categoric" src="https://dl.dropboxusercontent.com/u/15056258/screeen.png">
+    </td>
+    <td>
+      <h2 id="octopreview">
+        <a href="https://chrome.google.com/webstore/detail/octo-preview/elomekmlfonmdhmpmdfldcjgdoacjcba"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/DrewML/octo-preview">OctoPreview</a>
+      </h2>
+      <p>Displays live previews of Markdown comments while you type. Works with Issues + Pull Requests.</p>
+      <img width="250" alt="GitHub OctoPreview Extension" src="https://raw.githubusercontent.com/DrewML/octo-preview/master/example.gif">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="refined-github">
+        <a href="https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/fantattitude/refined-github-safari"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/safari/safari_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/refined-github">Refined GitHub</a>
+      </h2>
+      <p>Extension that simplifies the GitHub interface and adds useful features.</p>
+      <img width="250" alt="Refined GitHub" src="https://raw.githubusercontent.com/sindresorhus/refined-github/master/screenshot-dashboard.png">
+    </td>
+    <td>
+      <h2 id="show-all-github-issues">
+        <a href="https://chrome.google.com/webstore/detail/show-all-github-issues/ahkcgmpcfiijldaijfjekdffckpidieb"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://addons.opera.com/en/extensions/details/github-issues-all/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/opera/opera_48x48.png" width="24" /></a>
+        <a href="https://github.com/sindresorhus/show-all-github-issues">Show All GitHub Issues</a>
+      </h2>
+      <p>Show both Issues and Pull Requests in the Issues tab by default. As it previously did.</p>
+      <img width="250" alt="Show All GitHub Issues" src="https://raw.githubusercontent.com/sindresorhus/show-all-github-issues/master/screenshot.png">
+    </td>
+    <td>
+      <h2 id="contributors-on-github">
+        <a href="https://chrome.google.com/webstore/detail/contributors-on-github/cjbacdldhllelehomkmlniifaojgaeph"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/hzoo/contributors-on-github">Contributors on GitHub</a>
+      </h2>
+      <p>Show the # of PRs and other contributors stats in the Issues/PRs tab. Can be helpful for maintainers that want to know if it's a contributor's first PR.</p>
+      <img width="250" alt="Contributors on GitHub" src="https://github.com/hzoo/contributors-on-github/blob/master/firstpr.gif">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="gifhub">
+        <a href="https://chrome.google.com/webstore/detail/gifhub/lponagpckglibniamicamklhfkoebpeb/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/DrewML/GifHub">GifHub</a>
+      </h2>
+      <p>A Chrome extension that adds a button on GitHub comment toolbars, allowing you to search for (and include) GIFs in comments.</p>
+      <img width="250" alt="GifHub" src="https://cloud.githubusercontent.com/assets/1393946/13860430/911b4ce6-ec88-11e5-9952-11f19baa0190.gif">
+    </td>
+    <td>
+      <h2 id="github-omnibar">
+        <a href="https://chrome.google.com/webstore/detail/github-omnibar/njccjmmakcbdpnlbodllfgiloenfpocb"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/jcouyang/gh-omnibar#firefox"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/jcouyang/gh-omnibar">GitHub Omnibar</a>
+      </h2>
+      <p>Omnibar for GitHub just like <a href="https://developer.atlassian.com/blog/2016/02/6-secret-bitbucket-features/?categories=git#omnibar">bitbucket's</a></p>
+      <img width="250" src="https://cloud.githubusercontent.com/assets/1235045/13912608/00623f8a-ef7a-11e5-92dc-20cd9815007d.png">
+    </td>
+    <td>
+      <h2 id="twitter-for-github">
+        <a href="https://chrome.google.com/webstore/detail/twitter-for-github/joalalcafnlmimkfkihjbdgmphgedojc"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/bevacqua/twitter-for-github">Twitter for GitHub</a>
+      </h2>
+      <p>Infers or tries to find GitHub users' Twitter handles and present them to you in the GitHub interface.</p>
+      <img width="250" src="https://cloud.githubusercontent.com/assets/1393946/14272254/9a83b0a2-fb01-11e5-8d04-52687ae367f8.png">
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="where-is-it">
+        <a href="https://chrome.google.com/webstore/detail/where-is-it/cdgnplmebagbialenimejpokfcodlkdm"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/WhereIsItDev/whereisit">Where is it?</a>
+      </h2>
+      <p>Whereisit makes code navigation on GitHub easier. Look up and jump around class/method definitions with a single click.</p>
+      <img width="250" src="https://cloud.githubusercontent.com/assets/1393946/15090769/d0472958-1433-11e6-8af0-c5294aae94d6.png">
+    </td>
+    <td>
+      <h2 id="review-on-github">
+        <a href="https://chrome.google.com/webstore/detail/review-on-github/eenlonmglmdookfbknbmcgjkpomndjdp"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/bastilian/ReviewOnGitHub">Review on Github</a>
+      </h2>
+      <p>Review repositories on GitHub like a Pull Request. This extension adds the ability to github.com to make notes in files and add them as a compiled list to an issue.</p>
+    </td>
+    <td>
+      <h2 id="github-extended">
+        <a href="https://chrome.google.com/webstore/detail/github-extended/doidfnmbfadacpcjkekkgofkmnkljnhi/related"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/onmyway133/github-extended">GitHub Extended</a>
+      </h2>
+      <p>A Chrome extension to discover more repositories</p>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="npm-hub">
+        <a href="https://chrome.google.com/webstore/detail/npm-hub/kbbbjimdjbjclaebffknlabpogocablj"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="http://crossrider.com/install/36212-npm-hub"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/firefox/firefox_48x48.png" width="24" /></a>
+        <a href="https://github.com/zeke/npm-hub">npm-hub</a>
+      </h2>
+      <p>When viewing a repository on github.com that has a package.json file, this extension will introspect the dependencies in package.json and display links and description for each dependency, just below the repo's README.</p>
+      <img width="250" src="https://cloud.githubusercontent.com/assets/1393946/15631842/9dfd38f6-257d-11e6-96b8-f7008937e1ad.png">
+    </td>
+    <td>
+      <h2 id="pr-file-filter-for-github">
+        <a href="https://chrome.google.com/webstore/detail/pr-file-filter-for-github/jahafomboikfnemnncinlmohmbbbnbkn"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/siggysamson/pr-file-filter-for-github#pr-file-filter-for-github">PR file filter for Github</a>
+      </h2>
+      <p>This Chrome extension extends the file search of a pull request to allow for actual filtering with globs.</p>
+      <img width="250" src="https://raw.githubusercontent.com/siggysamson/pr-file-filter-for-github/master/assets/demo.gif">
+    </td>
+    <td>
+      <h2 id="github-travis-stat">
+        <a href="https://chrome.google.com/webstore/detail/github-travis-stat/ekkfhiophiaakmeppcnkblpbbjlnlnmh"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/Yaowenjie/travis-github-chrome-extension">Github Travis Stat</a>
+      </h2>
+      <p>This extension is to display travis-ci status for repos in github. There is a visual chart which shows build status and duration changes for recent 10 times.</p>
+      <img width="250" src='http://yaowenjie.github.io/images/2016/travis0.png'/>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <h2 id="github-grouped-news">
+        <a href="https://chrome.google.com/webstore/detail/github-grouped-news/failppjoidijbialknplliogdmabniaf"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_48x48.png" width="24" /></a>
+        <a href="https://github.com/bfred-it/GitHub-Grouped-News">GitHub Grouped News</a>
+      </h2>
+      <p>Group stars, forks, and other events in your dashboard/news feed.</p>
+      <img width="250" src="https://raw.githubusercontent.com/bfred-it/GitHub-Grouped-News/master/screenshot.png">
+    </td>
+    <td colspan="2"></td>
+  </tr>
+</table>


### PR DESCRIPTION
I've reformatted the extension list as a 3-column table in this PR for #37. It looks a little wonky in my Chrome but I'm not the best with Markdown+HTML so maybe there's a better way. In the spirit of increasing usability another approach might be to simply make the extension images much smaller, increasing the number of items per screen height.