### PR TITLE
Add OctoPermalinker

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,16 @@ A missing button for automatic merge on build succeeds on Github. If you've revi
 ## [OctoPermalinker](https://github.com/josephfrazier/octopermalinker)
 <a href="https://chrome.google.com/webstore/detail/octopermalinker/bcnkgcoohaaaclieohdlkphgfinkgbfm"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a>
 
-Fixes stale source code links in comments and gists.
+OctoPermalinker is a browser extension that searches GitHub comments/files for links to files on branches,
+and adds a link to where the branch pointed when the comment/file was made/updated.
+This helps you avoid following a link that was broken after being posted.
+For context, here's some discussion about broken GitHub links:
+[Don't link to line numbers in GitHub](https://news.ycombinator.com/item?id=8046710).
+
+For example, suppose you're looking at a gist that links to a file on the master branch of a repo.
+At the time the gist was made, the link worked, but if the file gets removed, the link is broken.
+OctoPermalinker uses the gist creation date to add a permalink that still works.
+Here are some screencasts demonstrating the difference:
 
 <details><summary>Screenshots</summary>
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [Octo Mate](#octo-mate)
 - [OctoLinker](#octolinker)
 - [Octomerge](#octomerge)
+- [OctoPermalinker](#octopermalinker)
 - [OctoPreview](#octopreview)
 - [Octotree](#octotree)
 - [OctoTern](#octotern)
@@ -432,6 +433,21 @@ A missing button for automatic merge on build succeeds on Github. If you've revi
 
 <details><summary>Screenshots</summary>
   <img src="https://raw.githubusercontent.com/tennisonchan/octomerge/351bc660a7ad994f7f671a7a8365b09b0316c3f5/screenshots/screenshot-1.png">
+</details>
+
+
+## [OctoPermalinker](https://github.com/josephfrazier/octopermalinker)
+<a href="https://chrome.google.com/webstore/detail/octopermalinker/bcnkgcoohaaaclieohdlkphgfinkgbfm"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a>
+
+Fixes stale source code links in comments and gists.
+
+<details><summary>Screenshots</summary>
+
+### Before
+![Imgur](http://i.imgur.com/0x7mF6h.gif)
+
+### After
+![Imgur](http://i.imgur.com/NmyKDRk.gif)
 </details>
 
 


### PR DESCRIPTION
[OctoPermalinker](https://github.com/josephfrazier/octopermalinker) is a browser extension that searches GitHub comments/files for links to files on branches, and adds a link to where the branch pointed when the comment/file was made/updated. This helps you avoid following a link that was broken after being posted. For context, here's some discussion about broken GitHub links: [Don't link to line numbers in GitHub](https://news.ycombinator.com/item?id=8046710).

For example, suppose you're looking at a gist that links to a file on the master branch of a repo. At the time the gist was made, the link worked, but if the file gets removed, the link is broken. OctoPermalinker uses the gist creation date to add a permalink that still works. Here are some screencasts demonstrating the difference:

# Before
![Imgur](http://i.imgur.com/0x7mF6h.gif)

# After
![Imgur](http://i.imgur.com/NmyKDRk.gif)
