### PR TITLE
Link to the Sourcegraph browser extension's code

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ This extension is to display travis-ci status for repos in GitHub. There is a vi
   <img src='https://yaowenjie.github.io/images/2016/travis0.png'/>
 </details>
 
-## Sourcegraph for GitHub <a href="https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a> <a href="https://addons.mozilla.org/en-US/firefox/addon/sourcegraph/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" width="24" /></a>
+## [Sourcegraph](https://github.com/sourcegraph/browser-extensions) <a href="https://chrome.google.com/webstore/detail/sourcegraph/dgjhfomjieaadpoljlnidmbgkdffpack"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a> <a href="https://addons.mozilla.org/en-US/firefox/addon/sourcegraph/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" width="24" /></a>
 
 The Sourcegraph browser extension gives GitHub IDE-like powers when you're viewing code, pull requests, and diffs:
 


### PR DESCRIPTION
- The browser extension is now just "Sourcegraph", not "Sourcegraph for GitHub"
- The browser extension code is now open source at https://github.com/sourcegraph/browser-extensions