### PR TITLE
Add "asciinema Player for GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ ZenHub is the first and only project management suite that works natively within
  ![ZenHub](https://dl.dropboxusercontent.com/s/yosmyg8zsl5tyc5/zenhub.jpg)
 </details>
 
-## asciinema Player for GitHub <a href="https://chrome.google.com/webstore/detail/asciinema-player-for-gith/mkllmpcfhjcbkmegdpnaemhpdddffhil"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a>
+## [asciinema Player for GitHub](https://github.com/plibither8/asciinema-player-for-github) <a href="https://chrome.google.com/webstore/detail/asciinema-player-for-gith/mkllmpcfhjcbkmegdpnaemhpdddffhil"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a>
 
 This is a lightweight Chrome extension that automatically detects instances of [asciinema](https://asciinema.org) links in a README on GitHub and embeds the player in its place. Instead of being directed to the asciinema website to watch the "asciicast", watch it directly in the README (or any `.md`, `.rst`, `.textile`, [etc.](https://github.com/github/markup/blob/master/README.md#markups) file), thanks to the [embedded player widget](https://asciinema.org/docs/embedding). 🎉
 

--- a/README.md
+++ b/README.md
@@ -634,6 +634,15 @@ ZenHub is the first and only project management suite that works natively within
  ![ZenHub](https://dl.dropboxusercontent.com/s/yosmyg8zsl5tyc5/zenhub.jpg)
 </details>
 
+## asciinema Player for GitHub <a href="https://chrome.google.com/webstore/detail/asciinema-player-for-gith/mkllmpcfhjcbkmegdpnaemhpdddffhil"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a>
+
+This is a lightweight Chrome extension that automatically detects instances of [asciinema](https://asciinema.org) links in a README on GitHub and embeds the player in its place. Instead of being directed to the asciinema website to watch the "asciicast", watch it directly in the README (or any `.md`, `.rst`, `.textile`, [etc.](https://github.com/github/markup/blob/master/README.md#markups) file), thanks to the [embedded player widget](https://asciinema.org/docs/embedding). 🎉
+
+<details><summary>Screenshots</summary>
+
+ ![asciinema Player for GitHub](https://raw.githubusercontent.com/plibither8/asciinema-player-for-github/master/assets/demo.gif)
+</details>
+
 ## Search
 
 ### [GitHub Awesome Autocomplete](https://github.com/algolia/github-awesome-autocomplete) <a href="https://chrome.google.com/webstore/detail/awesome-autocomplete-for/djkfdjpoelphhdclfjhnffmnlnoknfnd"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" width="24" /></a> <a href="https://addons.mozilla.org/firefox/addon/github-awesome-autocomplete/"><img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" width="24" /></a>


### PR DESCRIPTION
A small extension I made to make it more convenient to view asciinema screencasts on GitHub :slightly_smiling_face:

-----
[View rendered README.md](https://github.com/plibither8/awesome-browser-extensions-for-github/blob/patch-1/README.md)