### PR TITLE
Fix screenshot url in the "What's New on GitHub" extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Helps you see easily which activities happened since you last visited GitHub.
 
 <details><summary>Screenshots</summary>
 
- ![What's New on GitHub](https://lh3.googleusercontent.com/y6qym1cFHDaY5R4e3F-p2ruKpUYT68pQ2wWiQy_1RGcPK3IS_e6C8R67_67UrRLa1mhSUaXewn8=w640-h400-e365)
+ ![What's New on GitHub](https://camo.githubusercontent.com/b167c82ff1f87582150a03ff81d20dc429274601/68747470733a2f2f6c68332e676f6f676c6575736572636f6e74656e742e636f6d2f7832744d704e41357757363330385a694e5a42474669506d714172653653716a48546d4d4d6d30585049764d43323063487167784e30362d324533566e375361367872695061595074673d77313238302d68383030)
 </details>
 
 


### PR DESCRIPTION
Based on issue: #126

-----
[View rendered README.md](https://github.com/tcelestino/awesome-browser-extensions-for-github/blob/docs/screenshot-url/README.md)