### PR TITLE
Add "Open Github file links in IDE"

### DIFF
--- a/data.json
+++ b/data.json
@@ -759,5 +759,20 @@
     "description": "Create, save, edit, pin, search and delete filters that you commonly use on the Github Issues and Pull Requests pages. You are able to scope filters to be shown globally (on each repo) or only have them show up on the repo you create them on. Pinning filters is also a feature that this extension allows you to do. So if you have several filters you use daily - you have a way to quickly access them, at the top of your list.",
     "installCount": 76,
     "lastUpdate": "27 Jan 2021"
+  },
+  {
+    "name": "Open GitHub file links in IDE",
+    "website": "https://github.com/lmichelin/open-github-links-in-ide",
+    "tags": [
+      "ide",
+      "code",
+      "pullrequest",
+      "codereview"
+    ],
+    "store": {
+      "chrome": "https://chrome.google.com/webstore/detail/open-github-in-ide/bmifnnfmccmleigpaolofacllndmfned",
+      "firefox": "https://addons.mozilla.org/firefox/addon/open-github-in-ide/"
+    },
+    "description": "This browser extension allows you to open files in your IDE directly from GitHub, assuming the repository you are working on is cloned on your computer. When a fragment of a file is displayed, your IDE opens the file and puts the cursor at the desired line."
   }
 ]


### PR DESCRIPTION
Hi ! 

I developed an extension to speed up code reviews :wink:

This browser extension allows you to open files in your IDE directly from GitHub, assuming the repository you are working on is cloned on your computer. When a fragment of a file is displayed, your IDE opens the file and puts the cursor at the desired line.

![image](https://user-images.githubusercontent.com/33673240/111086352-f8389100-851b-11eb-8854-ec1a07a5eca9.png)

![image](https://user-images.githubusercontent.com/33673240/111086230-55801280-851b-11eb-9b79-efecd4649a8f.png)