### PR TITLE
data.json: Add "Old School GitHub" extension

### DIFF
--- a/data.json
+++ b/data.json
@@ -782,11 +782,7 @@
     "name": "Old School GitHub",
     "source": "https://github.com/daattali/oldschool-github-extension",
     "tags": [
-      "github",
-      "chrome-extension",
-      "firefox-addon",
-      "firefox-extension",
-      "chrome-extensions"
+      "theme"
     ],
     "store": {
       "chrome": "https://chrome.google.com/webstore/detail/old-school-github/blkkkhifjoiedclojflfcenbjigdajeb",

--- a/data.json
+++ b/data.json
@@ -777,5 +777,21 @@
     "installCount": 228,
     "lastUpdate": "20 Mar 2021",
     "stars": 13
+  },
+  {
+    "name": "Old School GitHub",
+    "source": "https://github.com/daattali/oldschool-github-extension",
+    "tags": [
+      "github",
+      "chrome-extension",
+      "firefox-addon",
+      "firefox-extension",
+      "chrome-extensions"
+    ],
+    "store": {
+      "chrome": "https://chrome.google.com/webstore/detail/old-school-github/blkkkhifjoiedclojflfcenbjigdajeb",
+      "firefox": "https://addons.mozilla.org/addon/old-school-github/"
+    },
+    "description": "Revert GitHub's UI back to its classic look (before the June 23, 2020 update that has a flat, rounded and more whitespaced design)."
   }
 ]


### PR DESCRIPTION
This pull request adds an extension which reverts some of the design changes that were made to the GitHub UI back in June 2020.