### PR TITLE
Re-add `Contributors on GitHub` extension

### DIFF
--- a/data.json
+++ b/data.json
@@ -14,6 +14,22 @@
     "lastUpdate": "3 Jun 2021"
   },
   {
+    "name": "Contributors on GitHub",
+    "source": "https://github.com/hzoo/contributors-on-github",
+    "tags": [
+      "codereview",
+      "miscellaneous",
+      "profile",
+      "pullrequest",
+      "repository"
+    ],
+    "store": {
+      "chrome": "https://chrome.google.com/webstore/detail/contributors-on-github/cjbacdldhllelehomkmlniifaojgaeph",
+      "firefox": "https://addons.mozilla.org/en-US/firefox/addon/contributor-on-github/"
+    },
+    "description": "Show the # of PRs and other contributors stats in the Issues/PRs tab. Can be helpful for maintainers that want to know if it's a contributor's first PR."
+  },
+  {
     "name": "Git History",
     "source": "https://github.com/pomber/git-history",
     "tags": [


### PR DESCRIPTION
Follow-up of #174 

I've re-added "Contributors on GitHub", the only extension out of those 30 that is still active. It's super useful to have.

&nbsp;
Kindly cc @hzoo, as he is the author of the extension and the initial PR (#25): 
I've used the following tags in this PR:

```
      "codereview",
      "miscellaneous",
      "profile",
      "pullrequest",
      "repository"
```

Please suggest corrections if you find I didn't pick the proper ones.