### PR TITLE
Fix Chrome install count detection

### DIFF
--- a/update.js
+++ b/update.js
@@ -94,7 +94,7 @@ async function downloadStats(regexDownloads, regexVersion, storeUrl) {
 }
 
 async function chromeStats(storeUrl) {
-    return downloadStats(/content=\"UserDownloads:([0-9,]+)/, /h-C-b-p-D-xh-hh">([^<]+)/, storeUrl)
+    return downloadStats(/([0-9,]+) users/, /h-C-b-p-D-xh-hh">([^<]+)/, storeUrl)
 }
 async function firefoxStats(storeUrl) {
     return downloadStats(/average_daily_users":([0-9,]+)/, /AddonMoreInfo-last-updated">[^(]+\(([^)]+)/, storeUrl)


### PR DESCRIPTION
Last successful run was on Feb 11th:
https://github.com/stefanbuck/awesome-browser-extensions-for-github/actions/runs/7864390336/job/21456087719

After that all runs returned too many redirects or 0 installs for Chrome